### PR TITLE
Created a basic .travis.yml file for CI purposes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: java
+
+jdk:
+  - oraclejdk8
+  - openjdk8
+ 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,6 @@ jdk:
   - oraclejdk8
   - openjdk8
  
+cache:
+  directories:
+  - "$HOME/.m2"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Build Status](https://travis-ci.org/EconomicSL/housing-model.svg?branch=master)](https://travis-ci.org/EconomicSL/housing-model)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/a740a85350b54e49b49dd84157f30fac)](https://www.codacy.com/app/EconomicSL/housing-model?utm_source=github.com&utm_medium=referral&utm_content=EconomicSL/housing-model&utm_campaign=badger)
 
 Agent-Based Model of the UK Housing Market


### PR DESCRIPTION
@adrian-carro This PR is just adding CI to the housing model.  This will, at a minimum, prevent code that does compile on both oraclejdk8 and openjdk8 to being pushed to master, but will also be useful when there are more formal tests.